### PR TITLE
Use a number instead of latest

### DIFF
--- a/bin/asdf/asdf
+++ b/bin/asdf/asdf
@@ -179,7 +179,7 @@ inspect_args() {
 declare -a plugin_and_versions=(
 	"skaffold,2.2.0"
 	"skaffold,1.39.1"
-	"gcloud,latest"
+	"gcloud,422.0.0"
 	"helm,3.11.2"
 )
 

--- a/bin/asdf/src/lib/software.sh
+++ b/bin/asdf/src/lib/software.sh
@@ -1,7 +1,7 @@
 declare -a plugin_and_versions=(
 	"skaffold,2.2.0"
 	"skaffold,1.39.1"
-	"gcloud,latest"
+	"gcloud,422.0.0"
 	"helm,3.11.2"
 )
 


### PR DESCRIPTION
To prevent automatic updates use a number instead of latest 
to prevent errors in the future