### PR TITLE
Add stern to developer tools

### DIFF
--- a/tasks/developer-tools.yml
+++ b/tasks/developer-tools.yml
@@ -9,6 +9,17 @@
     - asdf
     - version-manager
 
+- name: Install stern
+  community.general.homebrew:
+    name: stern
+    state: present
+  tags:
+    - developer-tools
+    - install
+    - stern
+    - kubernetes
+    - logs
+
 - name: Install minikube
   community.general.homebrew:
     name: minikube


### PR DESCRIPTION
Stern is a tool that allow developers to group and 
filter logs from kubernetes